### PR TITLE
Configure Vercel deployment

### DIFF
--- a/studie-assistent/README.md
+++ b/studie-assistent/README.md
@@ -12,3 +12,10 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Deploy to Vercel
+
+1. Maak een account aan op [Vercel](https://vercel.com) en koppel deze repository.
+2. Stel in de Vercel settings de omgevingsvariabele `GEMINI_API_KEY` in.
+3. Vercel gebruikt het bijgeleverde `vercel.json` om het project te bouwen met `npm run build` en de map `dist` te deployen.
+4. Na het deployen is de applicatie direct online beschikbaar.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "studie-assistent/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` build settings so Vercel can deploy from `dist`
- document Vercel deployment steps

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee948cbb88330ba1c3ebe62663c5e