### PR TITLE
Fix Vercel config warning

### DIFF
--- a/studie-assistent/README.md
+++ b/studie-assistent/README.md
@@ -17,5 +17,5 @@ This contains everything you need to run your app locally.
 
 1. Maak een account aan op [Vercel](https://vercel.com) en koppel deze repository.
 2. Stel in de Vercel settings de omgevingsvariabele `GEMINI_API_KEY` in.
-3. Vercel gebruikt het bijgeleverde `vercel.json` om het project te bouwen met `npm run build` en de map `dist` te deployen.
+3. Vercel gebruikt het bijgeleverde `vercel.json` om `npm run build` uit te voeren en de map `dist` te deployen.
 4. Na het deployen is de applicatie direct online beschikbaar.

--- a/studie-assistent/vercel.json
+++ b/studie-assistent/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` without deprecated `builds` property
- clarify README deployment instructions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef35374d48330ad109ce9863b3b1a